### PR TITLE
feat: remember

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -17,6 +17,11 @@ security:
         main:
             anonymous: lazy
             provider: app_user_provider
+            remember_me:
+                secret: '%kernel.secret%'
+                lifetime: 31536000 #604800 # 1 week in seconds
+                path: /
+                token_provider: 'Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider'
             guard:
                 authenticators:
                     - App\Security\LoginFormAuthenticator

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,3 +25,4 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+    Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider: ~

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -48,6 +48,7 @@ class HomeController extends AbstractController
      */
     public function admin()
     {
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
         return $this->render('home/temporaire/admin.html.twig', [
             'controller_name' => 'HomeController',
         ]);


### PR DESCRIPTION
- Ajout du token pour le "remember me" dans le security.yaml
- Ajout du lifetime pour le "remember me" dans le security.yaml
- Ajout du token dans le services.yaml
- Config du controller admin pour refuser l'accès "a moin que" le token est actif